### PR TITLE
Bidstack Adapter: Add placementId optional field

### DIFF
--- a/adapters/bidstack/params_test.go
+++ b/adapters/bidstack/params_test.go
@@ -9,6 +9,7 @@ import (
 
 var validParams = []string{
 	`{"publisherId": "355cf800-8348-433a-9d95-70345fa70afc"}`,
+	`{"publisherId": "355cf800-8348-433a-9d95-70345fa70afc","placementId":"Some placement ID"}`,
 }
 
 var invalidParams = []string{

--- a/static/bidder-params/bidstack.json
+++ b/static/bidder-params/bidstack.json
@@ -9,6 +9,10 @@
       "format": "uuid",
       "minLength": 1,
       "description": "An ID which identifies the publisher in Bidstack system"
+    },
+    "placementId": {
+      "type": "string",
+      "description": "An ID which identifies the placement in Bidstack system"
     }
   },
   "required" : [ "publisherId" ]


### PR DESCRIPTION
PlacementID (internally called AdUnitID) field added.

No test cases fixes required since the field is optional (I guess), so only static/bidder_params and param validation is edited.